### PR TITLE
Update DCMotorControl.mo

### DIFF
--- a/VirtualFCS/Control/DCMotorControl.mo
+++ b/VirtualFCS/Control/DCMotorControl.mo
@@ -1,10 +1,9 @@
 within VirtualFCS.Control;
 model DCMotorControl
       //*** DEFINE REPLACEABLE PACKAGES ***//
-  replaceable parameter VirtualFCS.Utilities.ParameterRecords.DriveDataDcPm driveData annotation(
-    Placement(visible = true, transformation(extent = {{-152, -68}, {-132, -48}}, rotation = 0))) constrainedby
+  replaceable parameter VirtualFCS.Utilities.ParameterRecords.DriveDataDcPm driveData constrainedby
     Modelica.Electrical.Machines.Examples.ControlledDCDrives.Utilities.DriveDataDCPM
-    annotation (Placement(transformation(extent={{20,-80},{40,-60}})));
+    annotation(Placement(visible = true, transformation(extent = {{-152, -68}, {-132, -48}}, rotation = 0)));
 
 //*** INSTANTIATE COMPONENTS ***//
   Modelica.Electrical.Machines.Examples.ControlledDCDrives.Utilities.DcdcInverter armatureInverter(


### PR DESCRIPTION
fix conflict between `annotation` and `constrainedby`. The original version do not work in OpenModelica 1.17.0 and mworks 2020.