### PR TITLE
Remove duplicate entry after merger

### DIFF
--- a/VirtualFCS/Electrical/package.order
+++ b/VirtualFCS/Electrical/package.order
@@ -4,4 +4,3 @@ DC_DC_Converter
 DCConverterSwitch
 DCConverter
 SpeedControlledDCMotor
-DC_DC_Converter


### PR DESCRIPTION
The merging of #11 resulted in a duplicate entry due to the same missing entry was also added in 9dadb06b729d30eb60d22476198a5da7131dbc50.